### PR TITLE
For loop to double buffer size

### DIFF
--- a/mmd/buffer.go
+++ b/mmd/buffer.go
@@ -128,7 +128,9 @@ func (b *Buffer) ensureSpace(sz int) {
 	if cap(b.data) > need {
 		return
 	}
-	b.doubleCapacity()
+	for cap(b.data) <= need {
+		b.doubleCapacity()
+	}
 }
 
 func (b *Buffer) doubleCapacity() {

--- a/mmd/buffer.go
+++ b/mmd/buffer.go
@@ -125,9 +125,6 @@ func (b *Buffer) advance(sz int) int {
 
 func (b *Buffer) ensureSpace(sz int) {
 	need := b.index + sz
-	if cap(b.data) > need {
-		return
-	}
 	for cap(b.data) <= need {
 		b.doubleCapacity()
 	}


### PR DESCRIPTION
When we are calling the WriteString method in `buffer.go`, we may need more space than double the current capacity. At the moment we only double capacity, this will double until there is enough capacity and prevent the situation mentioned.

An example of that situation:

